### PR TITLE
fix(mangaspark): unbreak parser - site relocated to sparkmanga.net

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Mangaspark.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/ar/Mangaspark.kt
@@ -1,15 +1,14 @@
 package org.koitharu.kotatsu.parsers.site.madara.ar
 
-import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
-@Broken("Site is gone — root redirects to an unrelated domain")
 @MangaSourceParser("MANGASPARK", "Manga-Spark", "ar")
 internal class Mangaspark(context: MangaLoaderContext) :
-	MadaraParser(context, MangaParserSource.MANGASPARK, "manga-spark.com", pageSize = 10) {
+	MadaraParser(context, MangaParserSource.MANGASPARK, "sparkmanga.net", pageSize = 10) {
 	override val postReq = true
 	override val datePattern = "d MMMM، yyyy"
+	override val selectPage = "div.page-break, div.page-box, div.no-gaps"
 }


### PR DESCRIPTION
## What

`manga-spark.com` has relocated to **sparkmanga.net** (same "Manga Spark" brand, standard Madara / Spartacus theme). The `@Broken("Site is gone")` note was stale - the site moved, it is not gone.

## Changes
- Domain `manga-spark.com` -> `sparkmanga.net`
- Remove the stale `@Broken`
- Add a `selectPage` override: this theme serves page images from `div.reading-content > div.no-gaps` rather than the default `div.page-break`

## Verification (against the live, Cloudflare-passed DOM in a real browser)
- **List:** the parser's `madara_load_more` AJAX returns HTTP 200 with 10 `page-item-detail` cards (url, cover, title) - matches `pageSize = 10`.
- **Details:** `h1` title, description, and 90 `li.wp-manga-chapter` entries; chapter dates parse with the existing Arabic `datePattern`; `og:image` cover present.
- **Pages:** `div.reading-content div.no-gaps img.wp-manga-chapter-img` - 33 images that load.