### PR TITLE
fix: un-@Broken anikiga + drakecomic (Cloudflare cleared, flows verified)

### DIFF
--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Anikiga.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/madara/tr/Anikiga.kt
@@ -1,12 +1,10 @@
 package org.koitharu.kotatsu.parsers.site.madara.tr
 
-import org.koitharu.kotatsu.parsers.Broken
 import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.madara.MadaraParser
 
-@Broken("Blocked by Cloudflare challenge")
 @MangaSourceParser("ANIKIGA", "Anikiga", "tr")
 internal class Anikiga(context: MangaLoaderContext) :
 	MadaraParser(context, MangaParserSource.ANIKIGA, "anikiga.com") {

--- a/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/DrakeScans.kt
+++ b/src/main/kotlin/org/koitharu/kotatsu/parsers/site/mangareader/en/DrakeScans.kt
@@ -4,9 +4,7 @@ import org.koitharu.kotatsu.parsers.MangaLoaderContext
 import org.koitharu.kotatsu.parsers.MangaSourceParser
 import org.koitharu.kotatsu.parsers.model.MangaParserSource
 import org.koitharu.kotatsu.parsers.site.mangareader.MangaReaderParser
-import org.koitharu.kotatsu.parsers.Broken
 
-@Broken("Blocked by Cloudflare challenge")
 @MangaSourceParser("DRAKESCANS", "DrakeComic", "en")
 internal class DrakeScans(context: MangaLoaderContext) :
 	MangaReaderParser(context, MangaParserSource.DRAKESCANS, "drakecomic.org", 20, 10)


### PR DESCRIPTION
Un-breaks two parsers whose sites are live and whose `@Broken` "Cloudflare challenge" flag is stale. A real browser (which clears Cloudflare exactly like the app's WebView) confirms both flows work with the existing parser config.

### anikiga (Madara) — verified against the live CF-passed DOM
- list: `madara_load_more` AJAX -> 12 `page-item-detail` cards
- details: 53 `li.wp-manga-chapter`, date matches `datePattern`
- pages: `div.page-break` images load
- Only the stale `@Broken` removed; existing overrides correct.

### drakecomic (MangaReader) — verified against the live DOM
- list: 20 `.bsx` cards
- details: 139 chapters (`#chapterlist`), date matches
- pages: 43 `div#readerarea` imgs + `ts_reader` script, images load
- No overrides needed; only the stale `@Broken` removed.