### PR TITLE
fix(CuuTruyen): rewrite dead image hosts, fix DRM decode & add API he…

### DIFF
--- a/src/main/kotlin/tsuki/site/vi/CuuTruyenParser.kt
+++ b/src/main/kotlin/tsuki/site/vi/CuuTruyenParser.kt
@@ -281,17 +281,17 @@ internal class CuuTruyenParser(context: MangaLoaderContext) :
 	}
 
 	override fun intercept(chain: Interceptor.Chain): Response {
-		val response = chain.proceed(chain.request())
-		val fragment = response.request.url.fragment
-
-		if (fragment == null || !fragment.contains(DRM_DATA_KEY)) {
-			return response
-		}
-
-		return context.redrawImageResponse(response) { bitmap ->
-			val drmData = fragment.substringAfter(DRM_DATA_KEY)
-			unscrambleImage(bitmap, drmData)
-		}
+	    val response = storageHostInterceptor(chain)
+	    val fragment = response.request.url.fragment
+	
+	    if (fragment == null || !fragment.contains(DRM_DATA_KEY)) {
+	        return response
+	    }
+	
+	    return context.redrawImageResponse(response) { bitmap ->
+	        val drmData = fragment.substringAfter(DRM_DATA_KEY)
+	        unscrambleImage(bitmap, drmData)
+	    }
 	}
 
 	private fun unscrambleImage(bitmap: Bitmap, drmData: String): Bitmap {

--- a/src/main/kotlin/tsuki/site/vi/CuuTruyenParser.kt
+++ b/src/main/kotlin/tsuki/site/vi/CuuTruyenParser.kt
@@ -161,8 +161,8 @@ internal class CuuTruyenParser(context: MangaLoaderContext) :
 				publicUrl = "https://$domain/mangas/${jo.getLong("id")}",
 				title = jo.getString("name"),
 				altTitles = emptySet(),
-				coverUrl = if (server == MOBILE_COVER) jo.getString(MOBILE_COVER)
-                    else jo.getString(DESKTOP_COVER),
+				coverUrl = if (server == MOBILE_COVER) jo.getString(MOBILE_COVER).fixStorageHost()
+                    else jo.getString(DESKTOP_COVER).fixStorageHost(),
 				largeCoverUrl = null,
 				authors = setOfNotNull(author),
 				tags = emptySet(),
@@ -232,8 +232,8 @@ internal class CuuTruyenParser(context: MangaLoaderContext) :
 					source = source,
 				)
 			},
-			largeCoverUrl = if (server == MOBILE_COVER) json.getString(MOBILE_PANORAMA)
-				else json.getString(DESKTOP_PANORAMA),
+			largeCoverUrl = if (server == MOBILE_COVER) json.getString(MOBILE_PANORAMA).fixStorageHost()
+				else json.getString(DESKTOP_PANORAMA).fixStorageHost(),
 		)
 	}
 
@@ -242,9 +242,9 @@ internal class CuuTruyenParser(context: MangaLoaderContext) :
 		val json = webClient.httpGet(url).parseJson().getJSONObject("data")
 
 		return json.getJSONArray("pages").mapJSON { jo ->
-			val imageUrl = jo.getString("image_url").toHttpUrl().newBuilder()
+			val imageUrl = jo.getString("image_url").fixStorageHost().toHttpUrl().newBuilder()
 			val id = jo.getLong("id")
-			val drm = jo.getStringOrNull("drm_data")
+			val drm = jo.getStringOrNull("drm_data")?.filterNot { it.isWhitespace() }
 			if (!drm.isNullOrEmpty()) {
 				imageUrl.fragment(DRM_DATA_KEY + drm)
 			}
@@ -255,6 +255,29 @@ internal class CuuTruyenParser(context: MangaLoaderContext) :
 				source = source,
 			)
 		}
+	}
+
+	private fun String.fixStorageHost(): String {
+		var result = this
+		for ((from, to) in STORAGE_HOST_FALLBACK) {
+			result = result.replace(from, to)
+		}
+		return result
+	}
+
+	private fun storageHostInterceptor(chain: Interceptor.Chain): Response {
+		var request = chain.request()
+		STORAGE_HOST_FALLBACK[request.url.host]?.let { host ->
+			request = request.newBuilder()
+				.url(request.url.newBuilder().host(host).build())
+				.build()
+		}
+		if (request.url.encodedPath.startsWith("/api/")) {
+			request = request.newBuilder()
+				.header("Cuutruyen-Client", CLIENT_HEADER)
+				.build()
+		}
+		return chain.proceed(request)
 	}
 
 	override fun intercept(chain: Interceptor.Chain): Response {
@@ -448,9 +471,14 @@ internal class CuuTruyenParser(context: MangaLoaderContext) :
 	private companion object {
 		const val DRM_DATA_KEY = "drm_data="
 		const val DECRYPTION_KEY = "3141592653589793"
+		const val CLIENT_HEADER = "OfficialWebApp-20250805"
         const val MOBILE_COVER = "cover_mobile_url"
 		const val MOBILE_PANORAMA = "panorama_mobile_url"
         const val DESKTOP_COVER = "cover_url"
         const val DESKTOP_PANORAMA = "panorama_url"
+		val STORAGE_HOST_FALLBACK = mapOf(
+			"storage-ct.lrclib.net" to "storage-bravo.cuutruyen.net",
+			"storage-ct-riften.site" to "storage-charlie.cuutruyen.net",
+		)
 	}
 }


### PR DESCRIPTION
…ader

- Fix dead image hosts: The API may return dead storage hosts such as `storage-ct.lrclib.net` and `storage-ct-riften.site`. Added `fixStorageHost()` to rewrite them to active hosts (`storage-bravo.cuutruyen.net` / `storage-charlie.cuutruyen.net`) directly when creating model URLs for covers, panorama covers, and page images.
- Fix DRM decode: Some `drm_data` values contain whitespace/newline characters, which can break Base64 decoding. Strip whitespace before injecting DRM data into the image URL fragment so the decode -> XOR -> unscramble pipeline works correctly.
- Add API header: Added `Cuutruyen-Client: OfficialWebApp-20250805` to `/api/` requests via `storageHostInterceptor`, while also keeping the interceptor as a fallback for host rewriting.

Credit: Issue analysis and solution generated with the assistance of the Ox Alpha (max) AI model.

**PLEASE READ THIS**

I confirm that:

- [x] All relevant issues have been mentioned in the PR description (e.g., "Closes #???")
- [ ] I have built the library with these changes to update the number of available sources in the [Summary](https://github.com/YakaTeam/kotatsu-parsers/blob/master/.github/summary.yaml) file
- [ ] I have removed `@Broken` annotation if the issue causing it to malfunction has been resolved
- [ ] I have added a special type to `MangaSourceParser` annotation if necessary (e.g., "`type = ContentType.HENTAI`")
- [ ] I have added a specific language code to `MangaSourceParser` annotation if the source is not multilingual (e.g., `vi`)
- [x] I have not changed the parser class name and ensured it does not conflict with any existing class
- [ ] All declared sort orders and filters in `availableSortOrders`, `filterCapabilities`, and `getFilterOptions` are properly implemented in `getList()` OR `getListPage()` function
- [ ] I have followed the instructions and parser class skeleton provided in [this CONTRIBUTING guide](https://github.com/YakaTeam/kotatsu-parsers/blob/master/CONTRIBUTING.md)
- [x] This PR only creates / edits to a single source; any more than that will be automatically rejected by reviewers

**TESTING**

I confirm that:

- [ ] I have tested the parser for syntax errors by compiling the class with the library
- [ ] I have tested the parser by compiling, building, and packaging it with the debug application
- [ ] All sort orders and filters declared in `availableSortOrders`, `filterCapabilities`, and `getFilterOptions` work correctly in the debug application
- [ ] `getList()` OR `getListPage()` and `getDetails()` functions retrieve all necessary information
- [ ] `getPages()` function successfully retrieves all images from the source

> [!IMPORTANT]
> - You must provide accurate information before creating a pull request
> - Select only the tasks you have completed and leave blank if you haven't done them
> - This information will be verified against data retrieved from that source by the reviewers.

---

### Source Name (Language)

CuuTruyen (vi)

### Related Issues

N/A

### Description

N/A
